### PR TITLE
feat: 添加自动保存开关设置以提升编辑体验

### DIFF
--- a/app/app.tsx
+++ b/app/app.tsx
@@ -265,6 +265,8 @@ const openLink = (element: any, event: CustomEvent<{ nativeEvent: MouseEvent | R
 }
 
 const App = (props: { initialData: any }) => {
+  const enableAutoSave = urlParams.get('enableAutoSave') === 'true';
+
   // 300ms内没有修改才保存
   const debouncedSave = React.useCallback(
     debounce(() => { save("autosave"); }, 300),
@@ -279,7 +281,11 @@ const App = (props: { initialData: any }) => {
       return;
     }
     if (!window.excalidrawAPI) return;
-    debouncedSave();
+
+    // 只有启用自动保存时才执行防抖保存
+    if (enableAutoSave) {
+      debouncedSave();
+    }
   };
 
   let libraryChangeInitStatus = true;

--- a/src/i18n/en_US.json
+++ b/src/i18n/en_US.json
@@ -15,5 +15,7 @@
   "themeMode": "Theme Mode",
   "themeModeDescription": "Theme of window",
   "snippets": "Snippets",
-  "snippetsDescription": "Make SiYuan snippets available at Excalidraw"
+  "snippetsDescription": "Make SiYuan snippets available at Excalidraw",
+  "enableAutoSave": "Enable Auto Save",
+  "enableAutoSaveDescription": "Automatically save content during editing (always save when closing)"
 }

--- a/src/i18n/zh_CN.json
+++ b/src/i18n/zh_CN.json
@@ -15,5 +15,7 @@
   "themeMode": "主题模式",
   "themeModeDescription": "窗口的主题",
   "snippets": "代码片段",
-  "snippetsDescription": "让思源代码片段在Excalidraw中生效"
+  "snippetsDescription": "让思源代码片段在Excalidraw中生效",
+  "enableAutoSave": "启用自动保存",
+  "enableAutoSaveDescription": "编辑时自动保存内容（关闭时始终保存）"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -233,6 +233,7 @@ export default class ExcalidrawPlugin extends Plugin {
       this.data[STORAGE_NAME].editWindow = (dialog.element.querySelector("[data-type='editWindow']") as HTMLSelectElement).value;
       this.data[STORAGE_NAME].themeMode = (dialog.element.querySelector("[data-type='themeMode']") as HTMLSelectElement).value;
       this.data[STORAGE_NAME].snippets = Array.from(dialog.element.querySelectorAll("[data-type='snippets'] input[data-id]:checked")).map(element => element.getAttribute("data-id"));
+      this.data[STORAGE_NAME].enableAutoSave = (dialog.element.querySelector("[data-type='enableAutoSave']") as HTMLInputElement).checked;
       this.saveData(STORAGE_NAME, this.data[STORAGE_NAME]);
       this.reloadAllEditor();
       this.removeAllExcalidrawTab();
@@ -249,6 +250,7 @@ export default class ExcalidrawPlugin extends Plugin {
     if (typeof this.data[STORAGE_NAME].editWindow === 'undefined') this.data[STORAGE_NAME].editWindow = 'dialog';
     if (typeof this.data[STORAGE_NAME].themeMode === 'undefined') this.data[STORAGE_NAME].themeMode = "themeLight";
     if (typeof this.data[STORAGE_NAME].snippets === 'undefined') this.data[STORAGE_NAME].snippets = [];
+    if (typeof this.data[STORAGE_NAME].enableAutoSave === 'undefined') this.data[STORAGE_NAME].enableAutoSave = true;
 
     this.settingItems = [
       {
@@ -337,6 +339,16 @@ export default class ExcalidrawPlugin extends Plugin {
               checkbox.checked = true;
             }
           });
+          return element;
+        },
+      },
+      {
+        title: this.i18n.enableAutoSave,
+        direction: "column",
+        description: this.i18n.enableAutoSaveDescription,
+        createActionElement: async () => {
+          const element = HTMLToElement(`<input type="checkbox" class="b3-switch fn__flex-center" data-type="enableAutoSave">`) as HTMLInputElement;
+          element.checked = this.data[STORAGE_NAME].enableAutoSave;
           return element;
         },
       },
@@ -562,7 +574,7 @@ export default class ExcalidrawPlugin extends Plugin {
         const iframeID = encodeURIComponent(unicodeToBase64(`excalidraw-edit-tab-${imageInfo.imageURL}`));
         const editTabHTML = `
 <div class="excalidraw-edit-tab">
-    <iframe src="/plugins/siyuan-embed-excalidraw/app/?lang=${window.siyuan.config.lang.replace('_', '-')}${that.isDarkMode() ? "&dark=1" : ""}&iframeID=${iframeID}&imageURL=${encodeURIComponent(imageInfo.imageURL)}"></iframe>
+    <iframe src="/plugins/siyuan-embed-excalidraw/app/?lang=${window.siyuan.config.lang.replace('_', '-')}${that.isDarkMode() ? "&dark=1" : ""}&iframeID=${iframeID}&imageURL=${encodeURIComponent(imageInfo.imageURL)}&enableAutoSave=${that.data[STORAGE_NAME].enableAutoSave}"></iframe>
 </div>`;
         this.element.innerHTML = editTabHTML;
 
@@ -676,7 +688,7 @@ export default class ExcalidrawPlugin extends Plugin {
     <div class="edit-dialog-header resize__move"></div>
     <div class="edit-dialog-container">
         <div class="edit-dialog-editor">
-            <iframe src="/plugins/siyuan-embed-excalidraw/app/?lang=${window.siyuan.config.lang.replace('_', '-')}&fullscreenBtn=1${this.isDarkMode() ? "&dark=1" : ""}&iframeID=${iframeID}&imageURL=${encodeURIComponent(imageInfo.imageURL)}"></iframe>
+            <iframe src="/plugins/siyuan-embed-excalidraw/app/?lang=${window.siyuan.config.lang.replace('_', '-')}&fullscreenBtn=1${this.isDarkMode() ? "&dark=1" : ""}&iframeID=${iframeID}&imageURL=${encodeURIComponent(imageInfo.imageURL)}&enableAutoSave=${this.data[STORAGE_NAME].enableAutoSave}"></iframe>
         </div>
         <div class="fn__hr--b"></div>
     </div>


### PR DESCRIPTION
由于保存操作（特别是 html2canvas 处理）会造成 UI 阻塞，
频繁的自动保存会导致编辑体验明显卡顿。本提交添加了
自动保存开关，允许用户根据需要禁用自动保存，
改为手动保存以获得更流畅的编辑体验。

主要改动：
- 添加 enableAutoSave 设置项（默认启用以保持向后兼容）
- 在 iframe URL 中传递 enableAutoSave 参数
- 只有启用自动保存时才执行防抖保存
- 添加中英文翻译

## 关联 Issue

这个 PR 通过添加自动保存开关，缓解了以下编辑卡顿问题：

- Closes #42
- Closes #40